### PR TITLE
[#139694343] Gelocates map center

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -98,7 +98,7 @@ export function getRelatedPhotos() {
 
 export function getCurrentLocation() {
   return dispatch => {
-    (navigator && navigator.geolocation) ? (
+    if (navigator && navigator.geolocation) {
       navigator.geolocation.getCurrentPosition( geoposition => {
         const {latitude, longitude} = geoposition.coords;
         dispatch({
@@ -110,7 +110,9 @@ export function getCurrentLocation() {
             },
           },
         });
-      })) : dispatch({
+      });
+    } else {
+      dispatch({
         type: ACTION_TYPES.getCurrentLocation,
         payload: {
           coords: {
@@ -119,5 +121,6 @@ export function getCurrentLocation() {
           },
         },
       });
+    }
   };
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -8,6 +8,7 @@ export const ACTION_TYPES = {
   searchPhotos: 'SEARCH_PHOTOS',
   handleInput: 'HANDLE_INPUT',
   getRelatedPhotos: 'GET_RELATED_PHOTOS',
+  getCurrentLocation: 'GET_CURRENT_LOCATION',
 };
 
 // This handles loading photos on mount. Temporary.
@@ -92,5 +93,23 @@ export function getRelatedPhotos() {
         },
       });
     });
+  };
+}
+
+export function getCurrentLocation() {
+  return dispatch => {
+    (navigator && navigator.geolocation) && (
+      navigator.geolocation.getCurrentPosition( geoposition => {
+        const {latitude, longitude} = geoposition.coords;
+        dispatch({
+          type: ACTION_TYPES.getCurrentLocation,
+          payload: {
+            coords: {
+              lat: latitude,
+              lng: longitude,
+            },
+          },
+        });
+      }));
   };
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -98,7 +98,7 @@ export function getRelatedPhotos() {
 
 export function getCurrentLocation() {
   return dispatch => {
-    (navigator && navigator.geolocation) && (
+    (navigator && navigator.geolocation) ? (
       navigator.geolocation.getCurrentPosition( geoposition => {
         const {latitude, longitude} = geoposition.coords;
         dispatch({
@@ -110,6 +110,14 @@ export function getCurrentLocation() {
             },
           },
         });
-      }));
+      })) : dispatch({
+        type: ACTION_TYPES.getCurrentLocation,
+        payload: {
+          coords: {
+            lat: 43.6726438,
+            lng: -79.3866517,
+          },
+        },
+      });
   };
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -41,7 +41,8 @@ class App extends Component {
           showInfoWindow={this.props.showInfoWindow}
           showingInfoWindow={this.props.showingInfoWindow}
           setActiveMarker={this.props.setActiveMarker}
-          activeMarker={this.props.activeMarker} />
+          activeMarker={this.props.activeMarker}
+          coords={this.props.coords} />
         <RelatedPhotoGallery photos={this.props.relatedPhotos} />
       </main>
     );
@@ -70,6 +71,7 @@ App.propTypes = {
   searchPhotos: PropTypes.func,
   getRelatedPhotos: PropTypes.func,
   relatedPhotos: PropTypes.array,
+  coords: PropTypes.object,
 };
 
 const mapStateToProps = state => ({
@@ -80,6 +82,7 @@ const mapStateToProps = state => ({
   search: state.photos.search,
   status: state.photos.status,
   relatedPhotos: state.photos.relatedList,
+  coords: state.photos.coords,
 });
 
 const mapDispatchToProps = {

--- a/src/components/Photomap/Photomap.js
+++ b/src/components/Photomap/Photomap.js
@@ -30,15 +30,21 @@ class PhotoMap extends Component {
   }
 
   getPhotoFromID(photos, id) {
-    return (photos.length && id) ? photos.find( photo => photo.id === id ) : { name: 'N/A' };
+    return (photos.length && id) ? photos.find( photo => photo.id === id ) : null;
+  }
+
+  getNamefromPhoto(photo) {
+    return (photo && photo.name) ? photo.name : 'N/A';
   }
 
   render() {
     return (
       <Map
-        google={this.props.google}
         style={{width: '90%', height: '50%', display: 'block', margin: '0 auto'}}
-        zoom={3}
+        google={this.props.google}
+        initialCenter={{...this.props.coords}}
+        centerAroundCurrentLocation
+        zoom={5}
         onClick={this.onMapClicked}>
         { this.props.photos.map( (photo) => <Marker
           key={photo.id}
@@ -51,7 +57,7 @@ class PhotoMap extends Component {
           marker={this.props.activeMarker}
           visible={this.props.showingInfoWindow}
           onClose={this.onInfoWindowClose}>
-            <p>{this.getPhotoFromID(this.props.photos, this.props.selectedPhotoID).name || 'N/A'}</p>
+            <p>{this.getNamefromPhoto(this.getPhotoFromID(this.props.photos, this.props.selectedPhotoID))}</p>
         </InfoWindow>
       </Map>
     );
@@ -67,6 +73,7 @@ PhotoMap.propTypes = {
   showingInfoWindow: PropTypes.bool,
   setActiveMarker: PropTypes.func,
   activeMarker: PropTypes.object,
+  coords: PropTypes.object,
 };
 
 export default GoogleApiWrapper({

--- a/src/reducers/photos.js
+++ b/src/reducers/photos.js
@@ -8,6 +8,10 @@ const INITIAL_STATE = {
   search: '',
   status: false,
   relatedList: [],
+  coords: {
+    lat: 43.6726438,
+    lng: -79.3866517,
+  },
 };
 
 // Reducer
@@ -27,6 +31,8 @@ export const photos = (state = INITIAL_STATE, {type, payload}) => {
     return {...state, ...{list: payload.search, status: payload.status}};
   case ACTION_TYPES.getRelatedPhotos:
     return {...state, ...{relatedList: payload.photos}};
+  case ACTION_TYPES.getCurrentLocation:
+    return {...state, ...{coords: payload.coords}};
   default:
     return state;
   }


### PR DESCRIPTION
This update centres the Google map based on browser location using the `centerAroundCurrentLocation` google-maps-react prop. As well, the lat. and long. for Toronto is set in the initial state store, which is used to set the initial map location. I also created and action for getting the current browser location. In the end I didn't need it, but we might want to update map location eventually if the user is on the go. It should be removed if at the end of the project we do not use.

Finally, I refactored some functions in the PhotoMaps component so passing the photo name to the InfoMarker is a bit cleaner.