### PR TITLE
[#140812587] Search nearby photos

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -13,9 +13,9 @@ export const ACTION_TYPES = {
 };
 
 // This handles loading photos on mount. Temporary.
-export function getPhotos() {
+export function getPhotos(params) {
   return dispatch => {
-    get('/photos', {feature: 'popular', image_size: [1, 200], tags: 1})
+    get('/photos', params)
     .then(response => {
       dispatch({
         type: ACTION_TYPES.getPhotos,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -13,9 +13,9 @@ export const ACTION_TYPES = {
 };
 
 // This handles loading photos on mount. Temporary.
-export function getPhotos(params) {
+export function getPhotos(params, endpoint = '') {
   return dispatch => {
-    get('/photos', params)
+    get(`/photos${endpoint}`, params)
     .then(response => {
       dispatch({
         type: ACTION_TYPES.getPhotos,
@@ -54,22 +54,6 @@ export function setActiveMarker(activeMarker) {
     payload: {
       activeMarker,
     },
-  };
-}
-
-// In photo-gallery.js, we pass the keyword stored in the state to the searchPhotos function.
-export function searchPhotos(keyword) {
-  return dispatch => {
-    get('photos/search', {term: keyword, image_size: [1, 200]})
-    .then(response => {
-      dispatch({
-        type: ACTION_TYPES.searchPhotos,
-        payload: {
-          search: response.photos,
-          status: true,
-        },
-      });
-    });
   };
 }
 
@@ -116,9 +100,9 @@ export function getCurrentLocation() {
   };
 }
 
-export function getPhotoDetails(params) {
+export function getPhotoDetails(id) {
   return (dispatch, getState) => {
-    get(`/photos/${params}`, {image_size: 4, comments: 1, tags: 1})
+    get(`/photos/${id}`, {image_size: 4, comments: 1, tags: 1})
     .then(response => {
       dispatch({
         type: ACTION_TYPES.getPhotoDetails,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -27,6 +27,7 @@ export function getPhotos() {
   };
 }
 
+// Sets active photo on map marker click (Temporary?)
 export function setSelectedPhotoID(selectedPhotoID) {
   return {
     type: ACTION_TYPES.setSelectedPhotoID,
@@ -36,6 +37,7 @@ export function setSelectedPhotoID(selectedPhotoID) {
   };
 }
 
+// Toggles map infowindow display
 export function showInfoWindow(bool) {
   return {
     type: ACTION_TYPES.showInfoWindow,
@@ -45,25 +47,13 @@ export function showInfoWindow(bool) {
   };
 }
 
+// Sets active marker on map marker click (Temporary?)
 export function setActiveMarker(activeMarker) {
   return {
     type: ACTION_TYPES.setActiveMarker,
     payload: {
       activeMarker,
     },
-  };
-}
-
-// This updates the search state on input change so that we can access it when we call searchPhotos below.
-export function handleInput(keyword) {
-  return dispatch => {
-    dispatch({
-      type: ACTION_TYPES.handleInput,
-      payload: {
-        keyword: keyword,
-        status: false, // Prevents state keyword from showing on type after first search.
-      },
-    });
   };
 }
 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,14 +1,13 @@
 import React, { Component, PropTypes as T } from 'react';
 import { connect } from 'react-redux';
-
 import {
-  getPhotos,
-  setSelectedPhotoID,
-  showInfoWindow,
-  setActiveMarker,
-  searchPhotos,
-  handleInput,
+  getPhotos as gp,
+  setSelectedPhotoID as sspid,
+  showInfoWindow as siw,
+  setActiveMarker as sam,
+  searchPhotos as sp,
 } from '../../actions/index';
+
 import PhotoGallery from '../PhotoGallery/PhotoGallery';
 import PhotoMap from '../PhotoMap/PhotoMap';
 import Header from '../Header/Header';
@@ -16,14 +15,28 @@ import SearchForm from '../Forms/SearchForm';
 
 class App extends Component {
   componentDidMount() {
-    this.props.getPhotos();
+    const { getPhotos } = this.props;
+    getPhotos();
   }
 
   render() {
-    const { searchForm } = this.props;
+    const {
+      setSelectedPhotoID,
+      showInfoWindow,
+      setActiveMarker,
+      searchPhotos,
+      photos,
+      selectedPhotoID,
+      showingInfoWindow,
+      activeMarker,
+      status,
+      coords,
+      searchForm,
+    } = this.props;
+
     const handleSearchSubmit = e => {
       e.preventDefault();
-      return this.props.searchPhotos(searchForm.values.searchHashtag);
+      return searchPhotos(searchForm.values.searchKeyword);
     };
 
     return (
@@ -31,17 +44,17 @@ class App extends Component {
         <Header/>
         <main>
           <SearchForm onSubmit={ handleSearchSubmit } />
-          { searchForm && searchForm.values && <h4>{this.props.status && `#${searchForm.values.searchHashtag}`}</h4> }
-          <PhotoGallery photos={this.props.photos} />
+          { searchForm && searchForm.values && <h4>{status && `#${searchForm.values.searchKeyword}`}</h4> }
+          <PhotoGallery photos={photos} />
           <PhotoMap
-            photos={this.props.photos}
-            setSelectedPhotoID={this.props.setSelectedPhotoID}
-            selectedPhotoID={this.props.selectedPhotoID}
-            showInfoWindow={this.props.showInfoWindow}
-            showingInfoWindow={this.props.showingInfoWindow}
-            setActiveMarker={this.props.setActiveMarker}
-            activeMarker={this.props.activeMarker}
-            coords={this.props.coords} />
+            photos={photos}
+            setSelectedPhotoID={setSelectedPhotoID}
+            selectedPhotoID={selectedPhotoID}
+            showInfoWindow={showInfoWindow}
+            showingInfoWindow={showingInfoWindow}
+            setActiveMarker={setActiveMarker}
+            activeMarker={activeMarker}
+            coords={coords} />
         </main>
       </div>
     );
@@ -57,8 +70,6 @@ App.propTypes = {
   showingInfoWindow: T.bool,
   setActiveMarker: T.func.isRequired,
   activeMarker: T.object,
-  handleInput: T.func.isRequired,
-  search: T.string.isRequired,
   status: T.bool,
   searchPhotos: T.func.isRequired,
   coords: T.object,
@@ -70,20 +81,17 @@ const mapStateToProps = state => ({
   selectedPhotoID: state.photos.selectedPhotoID,
   showingInfoWindow: state.photos.showingInfoWindow,
   activeMarker: state.photos.activeMarker,
-  search: state.photos.search,
   status: state.photos.status,
-  relatedPhotos: state.photos.relatedList,
   coords: state.photos.coords,
-  searchForm: state.form.search,
+  searchForm: state.form.searchForm,
 });
 
 const mapDispatchToProps = {
-  getPhotos,
-  setSelectedPhotoID,
-  showInfoWindow,
-  setActiveMarker,
-  handleInput,
-  searchPhotos,
+  getPhotos: gp,
+  setSelectedPhotoID: sspid,
+  showInfoWindow: siw,
+  setActiveMarker: sam,
+  searchPhotos: sp,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -16,7 +16,7 @@ import SearchForm from '../Forms/SearchForm';
 class App extends Component {
   componentDidMount() {
     const { getPhotos } = this.props;
-    getPhotos();
+    getPhotos({feature: 'popular', image_size: [1, 200], tags: 1});
   }
 
   render() {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -54,9 +54,9 @@ class App extends Component {
     return (
       <div>
         <Header/>
-        <main>
+        <main className="container">
+         { searchForm && searchForm.values && searchForm.values.searchKeyword && <h4>{`#${searchForm.values.searchKeyword}`}</h4> }
           <SearchForm onSubmit={ handleSearchSubmit } />
-          { searchForm && searchForm.values && <h4>{`#${searchForm.values.searchKeyword}`}</h4> }
           <PhotoGallery photos={photos} />
           <PhotoMap
             photos={photos}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,7 +5,6 @@ import {
   setSelectedPhotoID as sspid,
   showInfoWindow as siw,
   setActiveMarker as sam,
-  searchPhotos as sp,
 } from '../../actions/index';
 
 import PhotoGallery from '../PhotoGallery/PhotoGallery';
@@ -16,27 +15,33 @@ import SearchForm from '../Forms/SearchForm';
 class App extends Component {
   componentDidMount() {
     const { getPhotos } = this.props;
-    getPhotos({feature: 'popular', image_size: [1, 200], tags: 1});
+    getPhotos({
+      feature: 'popular',
+      image_size: [1, 200],
+      tags: 1,
+    });
   }
 
   render() {
     const {
+      getPhotos,
       setSelectedPhotoID,
       showInfoWindow,
       setActiveMarker,
-      searchPhotos,
       photos,
       selectedPhotoID,
       showingInfoWindow,
       activeMarker,
-      status,
       coords,
       searchForm,
     } = this.props;
 
     const handleSearchSubmit = e => {
       e.preventDefault();
-      return searchPhotos(searchForm.values.searchKeyword);
+      return getPhotos({
+        term: searchForm.values.searchKeyword,
+        image_size: [1, 200],
+      }, '/search');
     };
 
     return (
@@ -44,7 +49,7 @@ class App extends Component {
         <Header/>
         <main>
           <SearchForm onSubmit={ handleSearchSubmit } />
-          { searchForm && searchForm.values && <h4>{status && `#${searchForm.values.searchKeyword}`}</h4> }
+          { searchForm && searchForm.values && <h4>{`#${searchForm.values.searchKeyword}`}</h4> }
           <PhotoGallery photos={photos} />
           <PhotoMap
             photos={photos}
@@ -70,8 +75,6 @@ App.propTypes = {
   showingInfoWindow: T.bool,
   setActiveMarker: T.func.isRequired,
   activeMarker: T.object,
-  status: T.bool,
-  searchPhotos: T.func.isRequired,
   coords: T.object,
   searchForm: T.object,
 };
@@ -81,7 +84,6 @@ const mapStateToProps = state => ({
   selectedPhotoID: state.photos.selectedPhotoID,
   showingInfoWindow: state.photos.showingInfoWindow,
   activeMarker: state.photos.activeMarker,
-  status: state.photos.status,
   coords: state.photos.coords,
   searchForm: state.form.searchForm,
 });
@@ -91,7 +93,6 @@ const mapDispatchToProps = {
   setSelectedPhotoID: sspid,
   showInfoWindow: siw,
   setActiveMarker: sam,
-  searchPhotos: sp,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -36,12 +36,19 @@ class App extends Component {
       searchForm,
     } = this.props;
 
+    const buildQueryParams = (imgSize = [1, 200]) => {
+      const term = (searchForm && searchForm.values && searchForm.values.searchKeyword) ? searchForm.values.searchKeyword : '';
+      const geo = (searchForm && searchForm.values && searchForm.values.within5km) ? `${coords.lat},${coords.lng},5km` : '';
+      return {
+        image_size: imgSize,
+        ...term && { term },
+        ...geo && { geo },
+      };
+    };
+
     const handleSearchSubmit = e => {
       e.preventDefault();
-      return getPhotos({
-        term: searchForm.values.searchKeyword,
-        image_size: [1, 200],
-      }, '/search');
+      return getPhotos(buildQueryParams(), '/search');
     };
 
     return (
@@ -59,7 +66,8 @@ class App extends Component {
             showingInfoWindow={showingInfoWindow}
             setActiveMarker={setActiveMarker}
             activeMarker={activeMarker}
-            coords={coords} />
+            coords={coords}
+            zoom={(searchForm && searchForm.values && searchForm.values.within5km) ? 12 : 5} />
         </main>
       </div>
     );
@@ -77,6 +85,7 @@ App.propTypes = {
   activeMarker: T.object,
   coords: T.object,
   searchForm: T.object,
+  zoom: T.number,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/Forms/SearchForm.js
+++ b/src/components/Forms/SearchForm.js
@@ -6,17 +6,19 @@ function SearchForm({
   onSubmit,
 }) {
   return (
-    <form onSubmit={ onSubmit }>
-      <div>
-        <label htmlFor="searchKeyword">Search for keyword:</label>
-        <Field name="searchKeyword" component="input" type="text" placeholder="eggs" />
-      </div>
-      <div>
-        <Field name="within5km" id="within5km" component="input" type="checkbox" />
-        <label htmlFor="within5km">within 5 km</label>
-      </div>
-      <button className="btn waves-effect waves-light" type="submit">Search</button>
-    </form>
+    <div className="container">
+      <form onSubmit={ onSubmit }>
+        <div>
+          <label htmlFor="searchKeyword">Search for keyword:</label>
+          <Field name="searchKeyword" component="input" type="text" placeholder="eggs" />
+        </div>
+        <div>
+          <Field name="within5km" id="within5km" component="input" type="checkbox" />
+          <label htmlFor="within5km">within 5 km</label>
+        </div>
+        <button className="btn waves-effect waves-light" type="submit">Search</button>
+      </form>
+    </div>
   );
 }
 

--- a/src/components/Forms/SearchForm.js
+++ b/src/components/Forms/SearchForm.js
@@ -6,7 +6,7 @@ function SearchForm({
   onSubmit,
 }) {
   return (
-    <div className="container">
+    <div>
       <form onSubmit={ onSubmit }>
         <div>
           <label htmlFor="searchKeyword">Search for keyword:</label>

--- a/src/components/Forms/SearchForm.js
+++ b/src/components/Forms/SearchForm.js
@@ -7,8 +7,9 @@ function SearchForm({
 }) {
   return (
     <form onSubmit={ onSubmit }>
-      <Field name="searchHashtag" component="input" type="text" placeholder="Search for stuff" />
-      <button className="btn waves-effect waves-light" type="submit">Submit</button>
+      <label htmlFor="searchKeyword">Search for keyword:</label>
+      <Field name="searchKeyword" component="input" type="text" placeholder="eggs" />
+      <button className="btn waves-effect waves-light" type="submit">Search</button>
     </form>
   );
 }
@@ -17,4 +18,4 @@ SearchForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
 };
 
-export default reduxForm({ form: 'search' })(SearchForm);
+export default reduxForm({ form: 'searchForm' })(SearchForm);

--- a/src/components/Forms/SearchForm.js
+++ b/src/components/Forms/SearchForm.js
@@ -7,8 +7,14 @@ function SearchForm({
 }) {
   return (
     <form onSubmit={ onSubmit }>
-      <label htmlFor="searchKeyword">Search for keyword:</label>
-      <Field name="searchKeyword" component="input" type="text" placeholder="eggs" />
+      <div>
+        <label htmlFor="searchKeyword">Search for keyword:</label>
+        <Field name="searchKeyword" component="input" type="text" placeholder="eggs" />
+      </div>
+      <div>
+        <Field name="within5km" id="within5km" component="input" type="checkbox" />
+        <label htmlFor="within5km">within 5 km</label>
+      </div>
       <button className="btn waves-effect waves-light" type="submit">Search</button>
     </form>
   );

--- a/src/components/PhotoGallery/PhotoGallery.js
+++ b/src/components/PhotoGallery/PhotoGallery.js
@@ -6,7 +6,7 @@ export default function PhotoGallery({
   photos,
 }) {
   return (
-    <div className="container">
+    <div className="container" style={{ marginTop: '2em'}}>
       <Images photos={photos}/>
     </div>
   );

--- a/src/components/PhotoGallery/PhotoGallery.js
+++ b/src/components/PhotoGallery/PhotoGallery.js
@@ -6,7 +6,7 @@ export default function PhotoGallery({
   photos,
 }) {
   return (
-    <div className="container" style={{ marginTop: '2em'}}>
+    <div style={{ marginTop: '2em'}}>
       <Images photos={photos}/>
     </div>
   );

--- a/src/components/PhotoMap/PhotoMap.js
+++ b/src/components/PhotoMap/PhotoMap.js
@@ -49,15 +49,16 @@ class PhotoMap extends Component {
       activeMarker,
       showingInfoWindow,
       selectedPhotoID,
+      zoom,
     } = this.props;
 
     return (
       <Map
         style={{width: '80%', height: '75%', display: 'block', margin: '0 auto'}}
         google={google}
-        initialCenter={{...coords}}
+        center={{...coords}}
         centerAroundCurrentLocation
-        zoom={5}
+        zoom={zoom}
         onClick={this.onMapClicked}>
         { photos.map( (photo) => <Marker
           key={photo.id}
@@ -90,6 +91,8 @@ PhotoMap.propTypes = {
   setActiveMarker: T.func.isRequired,
   activeMarker: T.object,
   coords: T.object,
+  zoom: T.number,
+  center: T.object,
 };
 
 export default GoogleApiWrapper({

--- a/src/components/PhotoMap/PhotoMap.js
+++ b/src/components/PhotoMap/PhotoMap.js
@@ -50,11 +50,16 @@ class PhotoMap extends Component {
       showingInfoWindow,
       selectedPhotoID,
       zoom,
+      loaded,
     } = this.props;
+
+    if (!loaded) {
+      return <p>Loading...</p>;
+    }
 
     return (
       <Map
-        style={{width: '100%', height: '75%', display: 'block'}}
+        style={{width: '70%', height: '75%', display: 'block', margin: '0 auto'}}
         google={google}
         center={{...coords}}
         centerAroundCurrentLocation
@@ -93,6 +98,7 @@ PhotoMap.propTypes = {
   coords: T.object,
   zoom: T.number,
   center: T.object,
+  loaded: T.bool,
 };
 
 export default GoogleApiWrapper({

--- a/src/components/PhotoMap/PhotoMap.js
+++ b/src/components/PhotoMap/PhotoMap.js
@@ -59,7 +59,7 @@ class PhotoMap extends Component {
 
     return (
       <Map
-        style={{width: '70%', height: '75%', display: 'block', margin: '0 auto'}}
+        style={{width: '70%', left: '-30vw', height: '75%', display: 'block', margin: '0 auto'}}
         google={google}
         center={{...coords}}
         centerAroundCurrentLocation

--- a/src/components/PhotoMap/PhotoMap.js
+++ b/src/components/PhotoMap/PhotoMap.js
@@ -54,7 +54,7 @@ class PhotoMap extends Component {
 
     return (
       <Map
-        style={{width: '80%', height: '75%', display: 'block', margin: '0 auto'}}
+        style={{width: '100%', height: '75%', display: 'block'}}
         google={google}
         center={{...coords}}
         centerAroundCurrentLocation

--- a/src/reducers/photos.js
+++ b/src/reducers/photos.js
@@ -28,8 +28,6 @@ export const photos = (state = INITIAL_STATE, {type, payload}) => {
     return {...state, ...{showingInfoWindow: payload.showingInfoWindow}};
   case ACTION_TYPES.setActiveMarker:
     return {...state, ...{activeMarker: payload.activeMarker}};
-  case ACTION_TYPES.handleInput:
-    return {...state, ...{search: payload.keyword, status: payload.status}};
   case ACTION_TYPES.searchPhotos:
     return {...state, ...{list: payload.search, status: payload.status}};
   case ACTION_TYPES.getRelatedPhotos:

--- a/src/reducers/photos.js
+++ b/src/reducers/photos.js
@@ -6,7 +6,6 @@ const INITIAL_STATE = {
   showingInfoWindow: false,
   activeMarker: {},
   search: '',
-  status: false,
   relatedList: [],
   coords: {
     lat: 43.6726438,
@@ -28,8 +27,6 @@ export const photos = (state = INITIAL_STATE, {type, payload}) => {
     return {...state, ...{showingInfoWindow: payload.showingInfoWindow}};
   case ACTION_TYPES.setActiveMarker:
     return {...state, ...{activeMarker: payload.activeMarker}};
-  case ACTION_TYPES.searchPhotos:
-    return {...state, ...{list: payload.search, status: payload.status}};
   case ACTION_TYPES.getRelatedPhotos:
     return {...state, ...{relatedList: payload.photos}};
   case ACTION_TYPES.getCurrentLocation:


### PR DESCRIPTION
**Major:** 
Adds a checkbox that lets you request photos within a 5km radius only. Map zooms in to show closer view of these markers. 

This PR also has major changes to actions and corresponding reducers: the `handleInput` function that was no longer getting used was deleted, as well, `searchPhotos` and `getPhotos` functions were combined into a single action that accepts params and an optional endpoint string that are then specified where the action is called (not hard-coded).

**Minor:**
- this.props destructured in App component
- adds a function `buildQueryParams` to build params object from the now more complex React Form form values
- renames form to `searchForm`
- adjusts CSS to centre content
- using a `status` state value to prevent the hashtag appearing in the `<h4>` until submit had an issue where if you'd already submitted one keyword search, then if you typed anything new in the input field it would appear in the `<h4>`. I think we can use different logic (React Form validation?) to handle this, but left it out of this PR for now.